### PR TITLE
Add sequence number to parsed records from log files

### DIFF
--- a/dfindexeddb/leveldb/log.py
+++ b/dfindexeddb/leveldb/log.py
@@ -62,7 +62,7 @@ class ParsedInternalKey:
       base_offset: the base offset for the parsed internal key value record.
       sequence_number: the sequence number for the parsed internal key value
           record.
-    
+
     Returns:
       A ParsedInternalKey
 
@@ -121,12 +121,14 @@ class WriteBatch:
     records = []
     for relative_sequence_number in range(count):
       record = ParsedInternalKey.FromDecoder(
-          decoder, base_offset + offset, relative_sequence_number + sequence_number)
+          decoder, base_offset + offset,
+          relative_sequence_number + sequence_number
+      )
       records.append(record)
     return cls(
         offset=base_offset + offset,
-        sequence_number=sequence_number, 
-        count=count, 
+        sequence_number=sequence_number,
+        count=count,
         records=records)
 
   @classmethod

--- a/tests/dfindexeddb/leveldb/log.py
+++ b/tests/dfindexeddb/leveldb/log.py
@@ -87,6 +87,7 @@ class LogTest(unittest.TestCase):
     self.assertEqual(records[0].offset, 19)
     self.assertEqual(records[0].value, b'')
     self.assertEqual(records[0].type, 0)  # deleted
+    self.assertEqual(records[0].sequence_number, 3)
 
 
 if __name__ == '__main__':

--- a/tools/chrome_notifications/notifications.py
+++ b/tools/chrome_notifications/notifications.py
@@ -41,7 +41,6 @@ from google.protobuf.json_format import MessageToJson
 @dataclasses.dataclass
 class ChromeNotificationRecord:
   src_file: str = None
-  record_type: str = None
   offset: int = None
   key: str = None
   sequence_number: int = None
@@ -75,11 +74,9 @@ class ChromeNotificationRecord:
       ldb_record: Union[log.ParsedInternalKey, ldb.LdbKeyValueRecord]
   ) -> ChromeNotificationRecord:
     record = cls()
-    record.record_type = ldb_record.__class__.__name__
     record.offset = ldb_record.offset
     record.key = ldb_record.key.decode()
-    if hasattr(ldb_record, 'sequence_number'):
-      record.sequence_number = ldb_record.sequence_number  
+    record.sequence_number = ldb_record.sequence_number  
     record.type = ldb_record.type
 
     if not ldb_record.value:
@@ -112,7 +109,8 @@ class ChromeNotificationRecord:
     record.replaced_existing_notification = (
         notification_proto.replaced_existing_notification)
     record.num_clicks = notification_proto.num_clicks
-    record.num_action_button_clicks = notification_proto.num_action_button_clicks
+    record.num_action_button_clicks = (
+        notification_proto.num_action_button_clicks)
     record.creation_time = webkit_time.WebKitTime(
         timestamp=notification_proto.creation_time_millis
     ).CopyToDateTimeString()


### PR DESCRIPTION
#20 relates

* Adds sequence number to ParsedInternalKey records from log files.  The sequence number is derived from the WriteBatch record sequence number.
* updates the offset attribute of WriteBatch to be a physical offset, rather than a relative offset.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
