### PR TITLE
Add InternalRecordType enum for parsing ldb/log files

### DIFF
--- a/dfindexeddb/cli.py
+++ b/dfindexeddb/cli.py
@@ -38,6 +38,10 @@ _VALID_PRINTABLE_CHARACTERS = (
 class Encoder(json.JSONEncoder):
   """A JSON encoder class for dfindexeddb fields."""
   def default(self, o):
+    if dataclasses.is_dataclass(o):
+      o_dict = dataclasses.asdict(o)
+      o_dict['__type__'] = o.__class__.__name__
+      return o_dict
     if isinstance(o, bytes):
       out = []
       for x in o:
@@ -62,8 +66,7 @@ class Encoder(json.JSONEncoder):
 def _Output(structure, to_json=False):
   """Helper method to output parsed structure to stdout."""
   if to_json:
-    structure_dict = dataclasses.asdict(structure)
-    print(json.dumps(structure_dict, indent=2, cls=Encoder))
+    print(json.dumps(structure, indent=2, cls=Encoder))
   else:
     print(structure)
 

--- a/dfindexeddb/indexeddb/chromium.py
+++ b/dfindexeddb/indexeddb/chromium.py
@@ -1357,4 +1357,4 @@ class IndexedDBRecord:
       value=idb_value,
       sequence_number=record.sequence_number if hasattr(
           record, 'sequence_number') else None,
-      type=record.type)
+      type=record.record_type)

--- a/dfindexeddb/leveldb/definitions.py
+++ b/dfindexeddb/leveldb/definitions.py
@@ -41,3 +41,9 @@ class LogFilePhysicalRecordType(enum.IntEnum):
   FIRST = 2
   MIDDLE = 3
   LAST = 4
+
+
+class InternalRecordType(enum.IntEnum):
+  """Internal record types."""
+  DELETED = 0
+  VALUE = 1

--- a/dfindexeddb/leveldb/ldb.py
+++ b/dfindexeddb/leveldb/ldb.py
@@ -36,13 +36,13 @@ class KeyValueRecord:
     key: the key of the record.
     value: the value of the record.
     sequence_number: the sequence number of the record.
-    type: the type of the record.
+    record_type: the type of the record.
   """
   offset: int
   key: bytes
   value: bytes
   sequence_number: int
-  type: int
+  record_type: definitions.InternalRecordType
 
   @classmethod
   def FromDecoder(
@@ -69,9 +69,13 @@ class KeyValueRecord:
     sequence_number = int.from_bytes(
         key[-definitions.SEQUENCE_LENGTH:], byteorder='little', signed=False)
     key_type = shared_key[-definitions.PACKED_SEQUENCE_AND_TYPE_LENGTH]
-
-    return cls(offset + block_offset, key, value, sequence_number,
-               key_type), shared_key
+    record_type = definitions.InternalRecordType(key_type)
+    return cls(
+        offset=offset + block_offset,
+        key=key,
+        value=value,
+        sequence_number=sequence_number,
+        record_type=record_type), shared_key
 
 
 @dataclass

--- a/dfindexeddb/leveldb/log.py
+++ b/dfindexeddb/leveldb/log.py
@@ -29,18 +29,17 @@ class ParsedInternalKey:
 
   Attributes:
     offset: the offset of the record.
-    type: the record type.
+    record_type: the record type.
     sequence_number: the sequence number (inferred from the relative location
         the ParsedInternalKey in a WriteBatch.)
     key: the record key.
     value: the record value.
   """
   offset: int
-  type: int
+  record_type: definitions.InternalRecordType
   sequence_number: int
   key: bytes
   value: bytes
-  __type__: str = 'ParsedInternalKey'
 
   @classmethod
   def FromDecoder(
@@ -65,15 +64,17 @@ class ParsedInternalKey:
     """
     offset, record_type = decoder.DecodeUint8()
     _, key = decoder.DecodeBlobWithLength()
-    if record_type == 1:
+    record_type = definitions.InternalRecordType(record_type)
+
+    if record_type == definitions.InternalRecordType.VALUE:
       _, value = decoder.DecodeBlobWithLength()
-    elif record_type == 0:
+    elif record_type == definitions.InternalRecordType.DELETED:
       value =  b''
     else:
       raise ValueError(f'Invalid record type {record_type}')
     return cls(
         offset=base_offset + offset,
-        type=record_type,
+        record_type=record_type,
         key=key,
         value=value,
         sequence_number=sequence_number)

--- a/tests/dfindexeddb/leveldb/ldb.py
+++ b/tests/dfindexeddb/leveldb/ldb.py
@@ -48,7 +48,7 @@ class LDBTest(unittest.TestCase):
     self.assertEqual(records[0].value, b'test value\x00\x00\x00\x00')
     self.assertEqual(records[0].sequence_number, 0)
     self.assertEqual(
-        records[0].record_type, definitions.InternalRecordType.DELETED)
+        records[0].record_type, definitions.InternalRecordType.VALUE)
 
   def test_range_iter(self):
     """Tests the RangeIter method."""

--- a/tests/dfindexeddb/leveldb/ldb.py
+++ b/tests/dfindexeddb/leveldb/ldb.py
@@ -15,6 +15,7 @@
 """Unit tests for LevelDB Table (.ldb) files."""
 import unittest
 
+from dfindexeddb.leveldb import definitions
 from dfindexeddb.leveldb import ldb
 
 
@@ -46,7 +47,8 @@ class LDBTest(unittest.TestCase):
     self.assertEqual(records[0].key, b'\x00\x00\x00\x00')
     self.assertEqual(records[0].value, b'test value\x00\x00\x00\x00')
     self.assertEqual(records[0].sequence_number, 0)
-    self.assertEqual(records[0].type, 1)
+    self.assertEqual(
+        records[0].record_type, definitions.InternalRecordType.DELETED)
 
   def test_range_iter(self):
     """Tests the RangeIter method."""

--- a/tests/dfindexeddb/leveldb/log.py
+++ b/tests/dfindexeddb/leveldb/log.py
@@ -93,7 +93,8 @@ class LogTest(unittest.TestCase):
     # 7 (log file record header) + 12 (log file batch header) = 19
     self.assertEqual(records[0].offset, 19)
     self.assertEqual(records[0].value, b'')
-    self.assertEqual(records[0].type, 0)  # deleted
+    self.assertEqual(
+        records[0].record_type, definitions.InternalRecordType.DELETED)
     self.assertEqual(records[0].sequence_number, 3)
 
 


### PR DESCRIPTION
Adds an InternalRecordType enum which is used when parsing log/ldb files - #20 relates 

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
