### PR TITLE
Update version and pyproject gh action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -76,7 +76,6 @@ jobs:
       run: >-
         gh release create
         '${{ github.ref_name }}'
-        --verify-tag
         --repo '${{ github.repository }}'
         --notes ""
         --prerelease

--- a/dfindexeddb/version.py
+++ b/dfindexeddb/version.py
@@ -15,7 +15,7 @@
 """Version information for dfIndexeddb."""
 
 
-__version__ = "20240331a"
+__version__ = "20240402"
 
 
 def GetVersion():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfindexeddb"
-version = "20240331a"
+version = "20240402"
 requires-python = ">=3.8"
 description = "dfindexeddb is an experimental Python tool for performing digital forensic analysis of IndexedDB and leveldb files."
 license = {file = "LICENSE"}


### PR DESCRIPTION
* Bumps version to 20240402.
* Removes the --verify-tag option in the github action which appears to be causing 422 errors.