### PR TITLE
Update version and upload-artifact to 4.1.7

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.1.7
       with:
         name: python-package-distributions
         path: dist/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ options:
 
 #### Examples:
 
+To parse IndexedDB records from an sqlite file for Firefox and output the
+results as JSON, use the following command:
+
+```
+dfindexeddb db -s SOURCE --format firefox -o json
+```
+
 To parse IndexedDB records from an sqlite file for Safari and output the
 results as JSON-L, use the following command:
 

--- a/dfindexeddb/version.py
+++ b/dfindexeddb/version.py
@@ -15,7 +15,7 @@
 """Version information for dfIndexeddb."""
 
 
-__version__ = "20240519"
+__version__ = "20241031"
 
 
 def GetVersion():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dfindexeddb"
-version = "20240519"
+version = "20241031"
 requires-python = ">=3.8"
 description = "dfindexeddb is an experimental Python tool for performing digital forensic analysis of IndexedDB and leveldb files."
 license = {file = "LICENSE"}


### PR DESCRIPTION
Updates the GH action to use upload-artifact 4.1.7 (to fix broken GH action to publish distribution to PyPI)
Update version number in pyproject.toml and version.py
Update README with an example for Firefox