### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4.1.7
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
Change upload artifact to v4.1.7 didn't work. 
 
Using v4 as per https://github.com/actions/upload-artifact