### PR TITLE
Updates to Chromium IndexedDB parsing

### DIFF
--- a/dfindexeddb/indexeddb/chromium/definitions.py
+++ b/dfindexeddb/indexeddb/chromium/definitions.py
@@ -16,6 +16,11 @@
 from enum import Enum, IntEnum, IntFlag
 
 
+REQUIRES_PROCESSING_SSV_PSEUDO_VERSION = 0x11
+REPLACE_WITH_BLOB = 0x01
+COMPRESSED_WITH_SNAPPY = 0x02
+
+
 class DatabaseMetaDataKeyType(IntEnum):
   """Database Metadata key types."""
   ORIGIN_NAME = 0

--- a/dfindexeddb/indexeddb/chromium/record.py
+++ b/dfindexeddb/indexeddb/chromium/record.py
@@ -15,7 +15,6 @@
 """Parses Chromium IndexedDb structures."""
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
 from datetime import datetime
 import io

--- a/dfindexeddb/indexeddb/chromium/record.py
+++ b/dfindexeddb/indexeddb/chromium/record.py
@@ -436,7 +436,7 @@ class SchemaVersionKey(BaseIndexedDBKey):
 
   def DecodeValue(self, decoder: utils.LevelDBDecoder) -> int:
     """Decodes the schema version value."""
-    return decoder.DecodeVarint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(
@@ -456,7 +456,7 @@ class MaxDatabaseIdKey(BaseIndexedDBKey):
 
   def DecodeValue(self, decoder: utils.LevelDBDecoder) -> int:
     """Decodes the maximum database value."""
-    return decoder.DecodeVarint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(
@@ -476,7 +476,7 @@ class DataVersionKey(BaseIndexedDBKey):
 
   def DecodeValue(self, decoder: utils.LevelDBDecoder) -> int:
     """Decodes the data version value."""
-    return decoder.DecodeUint64Varint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(
@@ -638,7 +638,7 @@ class DatabaseNameKey(BaseIndexedDBKey):
 
     The value is the corresponding database ID.
     """
-    return decoder.DecodeVarint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(
@@ -785,7 +785,7 @@ class ObjectStoreNamesKey(BaseIndexedDBKey):
 
   def DecodeValue(self, decoder: utils.LevelDBDecoder) -> int:
     """Decodes the object store names value."""
-    return decoder.DecodeVarint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(cls, decoder: utils.LevelDBDecoder, key_prefix: KeyPrefix,
@@ -810,7 +810,7 @@ class IndexNamesKey(BaseIndexedDBKey):
 
   def DecodeValue(self, decoder: utils.LevelDBDecoder) -> int:
     """Decodes the index names value."""
-    return decoder.DecodeVarint()[1]
+    return decoder.DecodeInt()[1]
 
   @classmethod
   def FromDecoder(cls, decoder: utils.LevelDBDecoder, key_prefix: KeyPrefix,
@@ -847,7 +847,7 @@ class DatabaseMetaDataKey(BaseIndexedDBKey):
       return decoder.DecodeString()[1]
     if (self.metadata_type ==
         definitions.DatabaseMetaDataKeyType.MAX_ALLOCATED_OBJECT_STORE_ID):
-      return decoder.DecodeVarint()[1]
+      return decoder.DecodeInt()[1]
     if (self.metadata_type ==
         definitions.DatabaseMetaDataKeyType.IDB_INTEGER_VERSION):
       return decoder.DecodeVarint()[1]

--- a/tests/dfindexeddb/indexeddb/chromium/record.py
+++ b/tests/dfindexeddb/indexeddb/chromium/record.py
@@ -95,7 +95,7 @@ class ChromiumIndexedDBTest(unittest.TestCase):
     expected_key = record.DataVersionKey(
         offset=4, key_prefix=record.KeyPrefix(
             offset=0, database_id=0, object_store_id=0, index_id=0))
-    expected_value = 6424509460
+    expected_value = 64424509460
 
     record_bytes = ((b'\x00\x00\x00\x00\x02'), (b'\x14\x00\x00\x00\x0f'))
     parsed_key = record.DataVersionKey.FromBytes(record_bytes[0])

--- a/tests/dfindexeddb/indexeddb/chromium/record.py
+++ b/tests/dfindexeddb/indexeddb/chromium/record.py
@@ -579,7 +579,7 @@ class ChromiumIndexedDBTest(unittest.TestCase):
         encoded_user_key=record.IDBKey(
             offset=4, type=definitions.IDBKeyType.NUMBER, value=3.0))
     expected_value = record.ObjectStoreDataValue(
-        unknown=4,
+        version=4,
         is_wrapped=True,
         blob_offset=1,
         blob_size=2303,

--- a/tests/dfindexeddb/indexeddb/chromium/record.py
+++ b/tests/dfindexeddb/indexeddb/chromium/record.py
@@ -581,8 +581,8 @@ class ChromiumIndexedDBTest(unittest.TestCase):
     expected_value = record.ObjectStoreDataValue(
         version=4,
         is_wrapped=True,
-        blob_offset=1,
-        blob_size=2303,
+        blob_offset=0,
+        blob_size=102480,
         value=None)
     record_bytes = (
         b'\x00\x01\x01\x01\x03\x00\x00\x00\x00\x00\x00\x08@',

--- a/tests/dfindexeddb/indexeddb/chromium/record.py
+++ b/tests/dfindexeddb/indexeddb/chromium/record.py
@@ -95,7 +95,7 @@ class ChromiumIndexedDBTest(unittest.TestCase):
     expected_key = record.DataVersionKey(
         offset=4, key_prefix=record.KeyPrefix(
             offset=0, database_id=0, object_store_id=0, index_id=0))
-    expected_value = 20
+    expected_value = 6424509460
 
     record_bytes = ((b'\x00\x00\x00\x00\x02'), (b'\x14\x00\x00\x00\x0f'))
     parsed_key = record.DataVersionKey.FromBytes(record_bytes[0])


### PR DESCRIPTION
* Fix parsing bug for wrapped blobs in ObjectStoreDataKey
* Add support for wrapped snappy compressed values in ObjectStoreDataKey
* Update parsing of values in metadata keys from varint to int

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
